### PR TITLE
Support Laravel 5.8 new migrations

### DIFF
--- a/src/Migrations/2019_01_31_152149_create_posts_table.php
+++ b/src/Migrations/2019_01_31_152149_create_posts_table.php
@@ -15,7 +15,7 @@ class CreatePostsTable extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer("user_id")->unsigned();
+            $table->unsignedBigInteger('user_id');
             $table->foreign("user_id")->references("id")->on("users")->onDelete('cascade');
             $table->string("title")->nullable();
             $table->longText("content")->nullable();

--- a/src/Migrations/2019_02_07_085418_create_chat_discussions_table.php
+++ b/src/Migrations/2019_02_07_085418_create_chat_discussions_table.php
@@ -15,10 +15,10 @@ class CreateChatDiscussionsTable extends Migration
     {
         Schema::create('chat_discussions', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer("user_id")->unsigned();
+            $table->unsignedBigInteger('user_id');
             $table->foreign("user_id")->references('id')->on('users')->onDelete('cascade');
             $table->text('message');
-            $table->integer('receiver')->unsigned();
+            $table->unsignedBigInteger('receiver');
             $table->foreign('receiver')->references('id')->on('users')->onDelete('cascade');
             $table->timestamps();
         });

--- a/src/Migrations/2019_02_13_095148_create_user_informations_table.php
+++ b/src/Migrations/2019_02_13_095148_create_user_informations_table.php
@@ -15,7 +15,7 @@ class CreateUserInformationsTable extends Migration
     {
         Schema::create('user_informations', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('user_id')->unsigned();
+            $table->unsignedBigInteger('user_id');
             $table->foreign('user_id')->references('id')->on('users')->onCascade('delete');
             $table->string('Description')->nullable();
             $table->string('LastName')->nullable();

--- a/src/Migrations/2019_02_27_080903_create_followers_table.php
+++ b/src/Migrations/2019_02_27_080903_create_followers_table.php
@@ -16,7 +16,7 @@ class CreateFollowersTable extends Migration
     {
         Schema::create('followers', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('user_id')->unsigned();
+            $table->unsignedBigInteger('user_id');
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->integer('follow_id')->unsigned();
             $table->timestamps();

--- a/src/Migrations/2019_02_28_094806_create_checkouts_table.php
+++ b/src/Migrations/2019_02_28_094806_create_checkouts_table.php
@@ -15,7 +15,7 @@ class CreateCheckoutsTable extends Migration
     {
         Schema::create('checkouts', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('user_id')->unsigned();
+            $table->unsignedBigInteger('user_id');
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->string('FirstName',30);
             $table->string('LastName',30);

--- a/src/Migrations/2019_02_28_143101_create_stores_table.php
+++ b/src/Migrations/2019_02_28_143101_create_stores_table.php
@@ -15,7 +15,7 @@ class CreateStoresTable extends Migration
     {
         Schema::create('stores', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('user_id')->unsigned();
+            $table->unsignedBigInteger('user_id');
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->string('description');
             $table->float('price');


### PR DESCRIPTION
- Changes create migration to bigInteger so the foreign keys don't break when installing on fresh Laravel 5.8