### PR TITLE
Fix badges and laravel 5.6, 5.8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "phpunit/phpunit": "^7.0"
     },
     "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        },
         "laravel": {
             "providers": [
                 "Yasser\\LaravelDashboard\\DashboardServiceProvider"

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         }
     ],
     "require": {
-        "cartalyst/stripe-laravel": "9.0.*",
-        "cartalyst/stripe": "~2.0",
+        "cartalyst/stripe-laravel": "8.0.* || 9.0.* || 10.0.*",
+        "cartalyst/stripe": "^2.0",
         "nesbot/carbon": "^1.26.3 || ^2.0",
         "laravel/framework": "^5.4 || ^5.8"
     },
@@ -20,7 +20,6 @@
         }
     },
     "autoload-dev": {
-
         "psr-4": {
             "Yasser\\Tests\\": "Tests/"
         }

--- a/readme.md
+++ b/readme.md
@@ -3,11 +3,18 @@
 </p>
 
 <p align="center">
- <img src="https://img.shields.io/badge/build-passing-success.svg">
- <img src="https://img.shields.io/badge/php-90%25-informational.svg">
- <img src="https://img.shields.io/badge/coverity-passing-success.svg">
- <img src="https://img.shields.io/badge/license-MIT-success.svg">
- <img src="https://img.shields.io/badge/version-1.0.0-blue.svg">
+	<a href="https://packagist.org/packages/yal/laraveldash">
+		<img src="https://img.shields.io/packagist/v/yal/laraveldash.svg?label=stable" title="Stable Release">
+	</a>
+	<a href="https://packagist.org/packages/yal/laraveldash">
+		<img src="https://img.shields.io/packagist/dt/yal/laraveldash.svg" title="Downloads">
+	</a>
+	<a href="https://packagist.org/packages/yal/laraveldash">
+		<img src="https://img.shields.io/packagist/vpre/yal/laraveldash.svg?label=unstable" title="Unstable Release">
+	</a>
+	<a href="https://packagist.org/packages/yal/laraveldash">
+		<img src="https://img.shields.io/packagist/l/yal/laraveldash.svg" title="License">
+	</a>
 </p>
 
 ## About LaravelDash


### PR DESCRIPTION
replace fake badges by real badges but you have to add a license file .
add cartalyst/stripe-laravel 8.0.* and 10.0.* for laravel 5.6 and 5.8 support as v9.0.* only support laravel 5.7 .
alias master branch to prelease 1.0-dev to follow [SemVer](https://semver.org) standards .